### PR TITLE
babel-preset-es2015 loose-mode

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "stage-0", "react"]
+  "presets": [["es2015", {"loose": true}], "stage-0", "react"]
 }


### PR DESCRIPTION
Добавил loose-mode для пресета es2015. Необходим для работоспособности библиотечки в ie8