### PR TITLE
HTMLElement polyfill for IE8

### DIFF
--- a/src/Behaviour/ValidationWrapper.jsx
+++ b/src/Behaviour/ValidationWrapper.jsx
@@ -5,6 +5,10 @@ import PropTypes from "prop-types";
 import isEqual from "lodash.isequal";
 import smoothScrollIntoView from "./smoothScrollIntoView";
 
+if (typeof HTMLElement !== 'undefined') {
+    HTMLElement = window.Element;
+}
+
 export type Validation = {
     error: boolean,
     level: "error" | "warning",


### PR DESCRIPTION
При вызове ValidationContainer.validate(), вызывается вот этот код: https://github.com/skbkontur/react-ui-validations/blob/master/src/Behaviour/ValidationWrapper.jsx#L201

Проблема в том, что HTMLElement нет в IE8 и валидация падает с ошибкой: `Unhandled promise rejection: HTMLElement is undefined`.
Этот микро PR исправляет проблему.