### PR TITLE
На focus скроллим страницу к самому ValidationWrapper (если нет child)

### DIFF
--- a/src/Behaviour/ValidationWrapper.jsx
+++ b/src/Behaviour/ValidationWrapper.jsx
@@ -195,19 +195,17 @@ export default class ValidationWrapper extends React.Component<ValidationWrapper
     }
 
     async focus(): Promise<void> {
-        if (this.child) {
-            const childDomElement = ReactDom.findDOMNode(this.child);
-            if (childDomElement != null && childDomElement instanceof HTMLElement) {
-                await smoothScrollIntoView(
-                    childDomElement,
-                    this.context.validationContext.getSettings().scroll.verticalOffset || 50
-                );
-                if (this.child != null && typeof this.child.focus === "function") {
-                    this.child.focus();
-                }
+        const domElement = ReactDom.findDOMNode(this);
+        if (domElement != null && domElement instanceof HTMLElement) {
+            await smoothScrollIntoView(
+                domElement,
+                this.context.validationContext.getSettings().scroll.verticalOffset || 50
+            );
+            if (this.child != null && typeof this.child.focus === "function") {
+                this.child.focus();
             }
-            this.isChanging = false;
         }
+        this.isChanging = false;
     }
 
     getControlPosition(): ?{ x: number, y: number } {


### PR DESCRIPTION
Я столкнулся со странным поведением — когда я передаю в качестве `children` для `ValidationWrapper` хитрую иерархию компонентов, то, похоже, где-то по дороге теряется `ref`, ссылка на `clonedChild` в `this.child` не сохраняется и скроллинг в методе `focus` не отрабатывает.
Мы с @tihonove не разобрались, где именно теряется `ref`, но, кажется, будет вполне нормальным скроллить к самому врапперу, независимо от того, есть ли там `child`.